### PR TITLE
Review of ARRM

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -64,14 +64,14 @@ ARRM helps you assign responsibilities for digital accessibility to appropriate 
 
 Different aspects of accessibility are the responsibility of different roles, such as writers, designers, and developers. It is best to clearly define each role's responsibilities early in projects.
 
-When accessibility is left until late in a project, the responsibility often falls on developers. Then they end up handling tasks that are not in their skillset; for example, selecting colors, describing images, and writing headings.
+When accessibility is left until late in a project, the responsibility often falls on developers. Then they end up handling tasks that are not in their skillset — for example, selecting colors, describing images, and writing headings.
 
 ## What is ARRM
 
 Accessibility Roles and Responsibilities Mapping (ARRM) helps your team meet Web Content Accessibility Guidelines ([WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/)). ARRM provides guidance on which roles you can assign responsibilities for accessibility.
 
 {::nomarkdown}
-{% include_cached box.html type="start" title="Here is a simplified example." class="simple" %}
+{% include_cached box.html type="start" title="Here is a simplified example" class="simple" %}
 {:/}
 
 Roles that contribute to meeting WCAG requirements for headings:
@@ -83,7 +83,7 @@ Roles that contribute to meeting WCAG requirements for headings:
 {% include_cached box.html type="end" %}
 {:/}
 
-ARRM includes a high-level table of WCAG requirements — called "success criteria" — and a table of tasks that address the WCAG success criteria. The tables include primary, secondary, and contributor responsibilities.
+ARRM includes a table of high-level WCAG requirements — called "success criteria" — and a table of tasks that address the WCAG success criteria. The tables include primary, secondary, and contributor responsibilities.
 
 ## Typical roles and responsibilities
 
@@ -91,7 +91,7 @@ ARRM provides one approach for defining roles, tasks, and responsibilities. You 
 
 * **[Roles Involved in Accessibility](roles)**
 * **[WCAG Success Criteria](wcag-sc)** shows role responsibilities
-* **[Tasks Involved in Accessibility](tasks)** shows tasks you can use to help meet WCAG and role responsibilities<br>— a subset of the tasks are listed in these role pages:
+* **[Tasks Involved in Accessibility](tasks)** shows tasks you can do to help meet WCAG and role responsibilities — subsets of the tasks are listed for the different roles:
   * [User Experience (UX) Designer Responsibilities](user-experience)
   * [Visual Designer Responsibilities](visual-designer)
   * [Content Author Responsibilities](content-author)
@@ -101,10 +101,10 @@ ARRM provides one approach for defining roles, tasks, and responsibilities. You 
 
 Optionally, you can create accessibility roles and responsibilities based on your project and organization.
 
-* You can define different roles for your project team or use the typical [role definitions](roles)
-* You can assign responsibilities at the success criteria level or at the task level
-	* If at the task level, you can define different tasks or use the typical [tasks involved in accessibility](tasks)
-* For each success criteria or task, walk through the steps for deciding who is responsible using the **[ARRM Decision Tree](decision-tree)**
+* You can define different roles for your project team or use the typical [role definitions](roles).
+* You can assign responsibilities at the success criteria level or at the task level.
+	* If at the task level, you can define different tasks or use the typical [tasks involved in accessibility](tasks).
+* For each success criteria or task, walk through the steps for deciding who is responsible using the **[ARRM Decision Tree](decision-tree)**.
 
 ## Accessibility is about people
 

--- a/content/index.md
+++ b/content/index.md
@@ -91,7 +91,7 @@ ARRM provides one approach for defining roles, tasks, and responsibilities. You 
 
 * **[Roles Involved in Accessibility](roles)**
 * **[WCAG Success Criteria](wcag-sc)** shows role responsibilities
-* **[Tasks Involved in Accessibility](tasks)** shows tasks you can do to help meet WCAG and role responsibilities — subsets of the tasks are listed for the different roles:
+* **[Tasks Involved in Accessibility](tasks)** shows tasks you can use to help meet WCAG and their role responsibilities — subsets of the tasks are listed for these roles:
   * [User Experience (UX) Designer Responsibilities](user-experience)
   * [Visual Designer Responsibilities](visual-designer)
   * [Content Author Responsibilities](content-author)

--- a/content/index.md
+++ b/content/index.md
@@ -83,7 +83,7 @@ Roles that contribute to meeting WCAG requirements for headings:
 {% include_cached box.html type="end" %}
 {:/}
 
-ARRM includes a table of high-level WCAG requirements — called "success criteria" — and a table of tasks that address the WCAG success criteria. The tables include primary, secondary, and contributor responsibilities.
+ARRM includes a table of WCAG requirements — called "success criteria" — and a table of tasks that address the WCAG success criteria. The tables include primary, secondary, and contributor responsibilities.
 
 ## Typical roles and responsibilities
 


### PR DESCRIPTION
@shawna-slh - it's looking really good!

I noticed the following things you may want to correct:

1. Use an em dash instead of a semi-colon for the following sentence: 
Then they end up handling tasks that are not in their skillset **—** for example, selecting colors, describing images, and writing headings.

Rationale: An em dash sets off extra information, such as examples, or expands on something that precedes it. 

2. Remove the full stop in the header in the call-out box:
  Here is a simplified example

Rationale: Headers don't usually have full stops

3. Move the compound adjective: 
ARRM includes a table of **high-level** WCAG requirements ... and a table of tasks

Rationale: In this context, I don't think you can have a high-level or a low-level table

4. Change the verb from 'use' to 'do' in the following sentence: 
... shows tasks you can **do** to help meet WCAG and role responsibilities.  
Alternatively, you could say ' ... shows a list of tasks you can use to help meet WCAG'

Rationale: You can use a list of tasks to help meet WCAG, but applying 'use' with 'task' in the following example sounds strange to me: 'shows tasks you can use to clean the house'.

5. Remove the br element in the following list item: 
Tasks Involved in Accessibility shows tasks you can use to help meet WCAG and role responsibilities — a subset of the tasks are listed in these role pages ...

Rational: The br element is only appropriate for addresses, poems and the like — [Such blank lines must not be used for presentation purposes](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-br-element.html#:~:text=br%20elements%20must%20not%20be,thematic%20groups%20in%20a%20paragraph.&text=If%20a%20paragraph%20consists%20of,be%20used%20for%20presentation%20purposes.).

6. Correct grammar and make 'subset' plural (I would also suggest amending the wording for 'in these role pages': 
— subset**s** of the tasks are listed **for the following roles**: 
User Experience (UX) Designer Responsibilities
Visual Designer Responsibilities

Rationale: There is more than one subset

7. I don't understand the meaning of 'you can define different tasks': 
If at the task level, **you can define different tasks** or use the typical tasks involved in accessibility

What's confusing: Are you saying that people can define whatever tasks they like to improve accessibility?

8. Add full stops to the following list items:
- You can define different roles for your project team or use the typical role definitions.
- You can assign responsibilities at the success criteria level or at the task level. If at the task level, you can define different tasks or use the typical tasks involved in accessibility.
- For each success criteria or task, walk through the steps for deciding who is responsible using the ARRM Decision Tree.

Rationale: They are all complete sentences.