### PR TITLE
Update data submodule and symlinks

### DIFF
--- a/_data/techniques.yml
+++ b/_data/techniques.yml
@@ -1,1 +1,0 @@
-../_external/data/techniques.yml

--- a/_data/wcag.yml
+++ b/_data/wcag.yml
@@ -1,1 +1,0 @@
-../_external/data/wcag.yml

--- a/_data/wcag22.json
+++ b/_data/wcag22.json
@@ -1,0 +1,1 @@
+../_external/data/wcag22.json


### PR DESCRIPTION
This updates the data submodule to point at the latest commit and adds a new symlink, which enables incorporating updated WCAG data generated directly from output from the w3c/wcag repository via `site.data.wcag22.successcriteria`.

Two symlinks are removed, as the files no longer exist at those locations; their data was out-of-date and only used in a couple of specific locations elsewhere in the WAI website unrelated to this repository.

(RE the submodule update, note that PR previews and the live website under w3.org/WAI have already been incorporating more recent commits.)