### PR TITLE
Technical updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "_external/data"]
-	path = _external/data
-	url = https://github.com/w3c/wai-website-data.git
-  branch = master

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 
 # Gems loaded irrespective of site configuration.
 group :jekyll_plugins do
-    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'updates' # The theme of the site
-    gem 'wai-website-plugin', git: 'https://github.com/w3c/wai-website-plugin', branch: 'v2026' # The Jekyll plugins needed by the theme
+    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'main' # The theme of the site
+    gem 'wai-website-plugin', git: 'https://github.com/w3c/wai-website-plugin', branch: 'main' # The Jekyll plugins needed by the theme
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 # Gems loaded irrespective of site configuration.
 group :jekyll_plugins do
-    gem 'jekyll-remote-theme', '~>0.4.3'     # Use a GitHub-hosted theme
-    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'main' # The theme of the site
+    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'updates' # The theme of the site
     gem 'wai-website-plugin', git: 'https://github.com/w3c/wai-website-plugin', branch: 'v2026' # The Jekyll plugins needed by the theme
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem "wai-gems", :path => "_external/data/wai-gems"
+# Gems loaded irrespective of site configuration.
+group :jekyll_plugins do
+    gem 'jekyll-remote-theme', '~>0.4.3'     # Use a GitHub-hosted theme
+    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'main' # The theme of the site
+    gem 'wai-website-plugin', git: 'https://github.com/w3c/wai-website-plugin', branch: 'v2026' # The Jekyll plugins needed by the theme
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/w3c/wai-website-plugin
-  revision: 7cd3702a96d1b6a84c50fdfd3f6ceb62c72c69ae
-  branch: v2026
+  revision: e9f2c0e098caf80e010f1985ba942b6bf540e85e
+  branch: main
   specs:
     wai-website-plugin (0.3)
       jekyll (~> 4.4.1)
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/w3c/wai-website-theme
-  revision: f182969afb7a8fb47bd7434707f247b9302e11ba
-  branch: updates
+  revision: f33b9fef553b59ef8ecf35c3bef264de8b1ad4a9
+  branch: main
   specs:
     wai-website-theme (1.10)
       jekyll (~> 4.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/w3c/wai-website-theme
-  revision: 3317bc4e222c1433600d8b61204c7d0f5b13e7b7
-  branch: main
+  revision: f182969afb7a8fb47bd7434707f247b9302e11ba
+  branch: updates
   specs:
     wai-website-theme (1.10)
       jekyll (~> 4.4.1)
@@ -20,7 +20,6 @@ GIT
       jekyll-seo-tag (~> 2.8.0)
       jekyll-sitemap (~> 1.4.0)
       logger (~> 1.7.0)
-      wai-website-plugin (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -72,13 +71,8 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-remote-theme (0.4.3)
-      addressable (~> 2.0)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
-      rubyzip (>= 1.3.0, < 3.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
@@ -102,7 +96,7 @@ GEM
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (7.0.0)
+    public_suffix (7.0.2)
     racc (1.8.1)
     rake (13.3.1)
     rb-fsevent (0.11.2)
@@ -110,7 +104,6 @@ GEM
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (4.7.0)
-    rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass-embedded (1.97.1-arm64-darwin)
       google-protobuf (~> 4.31)
@@ -126,7 +119,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll-remote-theme (~> 0.4.3)
   wai-website-plugin!
   wai-website-theme!
 
@@ -150,8 +142,7 @@ CHECKSUMS
   jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
   jekyll-paginate (1.1.0) sha256=880aadf4b02529a93541d508c5cbb744f014cbfc071d0263a31f25ec9066eb64
   jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
-  jekyll-remote-theme (0.4.3) sha256=d3fde726484fb3df04de9e347baf75aaa3d5bfea771a330412e0c52608e54b40
-  jekyll-sass-converter (3.0.0) sha256=e2e7674f186e906b9d99b8066e13f9b4d5cb9f806d36f7bc8cf2610053d8c902
+  jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
@@ -165,14 +156,13 @@ CHECKSUMS
   nokogiri (1.19.0-arm64-darwin) sha256=0811dfd936d5f6dd3f6d32ef790568bf29b2b7bead9ba68866847b33c9cf5810
   nokogiri (1.19.0-x86_64-linux-gnu) sha256=f482b95c713d60031d48c44ce14562f8d2ce31e3a9e8dd0ccb131e9e5a68b58c
   pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
-  public_suffix (7.0.0) sha256=f7090b5beb0e56f9f10d79eed4d5fbe551b3b425da65877e075dad47a6a1b095
+  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
-  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
   sass-embedded (1.97.1-arm64-darwin) sha256=9da08e5cc569ef62235fc515a87c75a47b0de40d8416c563ba1abfbe60e606d9
   sass-embedded (1.97.1-x86_64-linux-gnu) sha256=9a294bb0acb1a539ed19f0e511098a9740b4aab4389e169585e8da1337fbd8b4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/w3c/wai-website-plugin
   revision: 7cd3702a96d1b6a84c50fdfd3f6ceb62c72c69ae
-  branch: add-theme-plugin
+  branch: v2026
   specs:
     wai-website-plugin (0.3)
       jekyll (~> 4.4.1)
@@ -72,6 +72,11 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -104,7 +109,8 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
-    rouge (4.6.1)
+    rouge (4.7.0)
+    rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass-embedded (1.97.1-arm64-darwin)
       google-protobuf (~> 4.31)
@@ -120,6 +126,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  jekyll-remote-theme (~> 0.4.3)
   wai-website-plugin!
   wai-website-theme!
 
@@ -143,6 +150,7 @@ CHECKSUMS
   jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
   jekyll-paginate (1.1.0) sha256=880aadf4b02529a93541d508c5cbb744f014cbfc071d0263a31f25ec9066eb64
   jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
+  jekyll-remote-theme (0.4.3) sha256=d3fde726484fb3df04de9e347baf75aaa3d5bfea771a330412e0c52608e54b40
   jekyll-sass-converter (3.0.0) sha256=e2e7674f186e906b9d99b8066e13f9b4d5cb9f806d36f7bc8cf2610053d8c902
   jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
@@ -163,7 +171,8 @@ CHECKSUMS
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
-  rouge (4.6.1) sha256=5075346d5797d6864be93f7adc75a16047a7dbfa572c63c502419ffa582c77de
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
   sass-embedded (1.97.1-arm64-darwin) sha256=9da08e5cc569ef62235fc515a87c75a47b0de40d8416c563ba1abfbe60e606d9
   sass-embedded (1.97.1-x86_64-linux-gnu) sha256=9a294bb0acb1a539ed19f0e511098a9740b4aab4389e169585e8da1337fbd8b4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,76 +1,77 @@
-PATH
-  remote: _external/data/wai-gems
+GIT
+  remote: https://github.com/w3c/wai-website-plugin
+  revision: 7cd3702a96d1b6a84c50fdfd3f6ceb62c72c69ae
+  branch: add-theme-plugin
   specs:
-    wai-gems (1.0.0)
-      jekyll-github-metadata
-      jekyll-include-cache
-      jekyll-paginate
-      jekyll-redirect-from
-      jekyll-relative-links
-      jekyll-remote-theme
-      jekyll-seo-tag
-      jekyll-sitemap
-      wai-website-plugin
+    wai-website-plugin (0.3)
+      jekyll (~> 4.4.1)
+      nokogiri (~> 1.19.0)
+
+GIT
+  remote: https://github.com/w3c/wai-website-theme
+  revision: 3317bc4e222c1433600d8b61204c7d0f5b13e7b7
+  branch: main
+  specs:
+    wai-website-theme (1.10)
+      jekyll (~> 4.4.1)
+      jekyll-include-cache (~> 0.2.1)
+      jekyll-paginate (~> 1.1.0)
+      jekyll-redirect-from (~> 0.16.0)
+      jekyll-seo-tag (~> 2.8.0)
+      jekyll-sitemap (~> 1.4.0)
+      logger (~> 1.7.0)
+      wai-website-plugin (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    bigdecimal (3.1.8)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
     colorator (1.1.0)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.9.2)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
-    google-protobuf (4.27.2-arm64-darwin)
+    google-protobuf (4.33.2-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.2-x86_64-linux)
+    google-protobuf (4.33.2-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    http_parser.rb (0.8.0)
-    i18n (1.14.5)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.3)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-github-metadata (2.16.1)
-      jekyll (>= 3.4, < 5.0)
-      octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-relative-links (0.7.0)
-      jekyll (>= 3.3, < 5.0)
-    jekyll-remote-theme (0.4.3)
-      addressable (~> 2.0)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
-      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -79,54 +80,98 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.4.0)
-      rexml
+    json (2.18.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
-    net-http (0.4.1)
-      uri
-    octokit (6.1.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-gnu)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.0)
-    rake (13.2.1)
+    public_suffix (7.0.0)
+    racc (1.8.1)
+    rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.1)
-      strscan
-    rouge (4.3.0)
-    rubyzip (2.3.2)
+    rexml (3.4.4)
+    rouge (4.6.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.5)
-      google-protobuf (>= 3.25, < 5.0)
-      rake (>= 13)
-    sass-embedded (1.77.5-arm64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sawyer (0.9.2)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
-    strscan (3.1.0)
+    sass-embedded (1.97.1-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.5.0)
-    uri (0.13.0)
-    wai-website-plugin (0.2)
-      jekyll (>= 3.6, < 5.0)
-    webrick (1.8.1)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
-  wai-gems!
+  wai-website-plugin!
+  wai-website-theme!
+
+CHECKSUMS
+  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
+  google-protobuf (4.33.2-arm64-darwin) sha256=6d0ac185fed18768e5f16338455b1e4b7c38a97fc46f352e709f7a3007b64e1d
+  google-protobuf (4.33.2-x86_64-linux-gnu) sha256=73cba041477afcac92ff383fcbdec195ea28d96b994876d1deaa944d18f91786
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
+  jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
+  jekyll-paginate (1.1.0) sha256=880aadf4b02529a93541d508c5cbb744f014cbfc071d0263a31f25ec9066eb64
+  jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
+  jekyll-sass-converter (3.0.0) sha256=e2e7674f186e906b9d99b8066e13f9b4d5cb9f806d36f7bc8cf2610053d8c902
+  jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
+  jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
+  jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
+  kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
+  listen (3.9.0) sha256=db9e4424e0e5834480385197c139cb6b0ae0ef28cc13310cfd1ca78377d59c67
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
+  nokogiri (1.19.0-arm64-darwin) sha256=0811dfd936d5f6dd3f6d32ef790568bf29b2b7bead9ba68866847b33c9cf5810
+  nokogiri (1.19.0-x86_64-linux-gnu) sha256=f482b95c713d60031d48c44ce14562f8d2ce31e3a9e8dd0ccb131e9e5a68b58c
+  pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  public_suffix (7.0.0) sha256=f7090b5beb0e56f9f10d79eed4d5fbe551b3b425da65877e075dad47a6a1b095
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (4.6.1) sha256=5075346d5797d6864be93f7adc75a16047a7dbfa572c63c502419ffa582c77de
+  safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
+  sass-embedded (1.97.1-arm64-darwin) sha256=9da08e5cc569ef62235fc515a87c75a47b0de40d8416c563ba1abfbe60e606d9
+  sass-embedded (1.97.1-x86_64-linux-gnu) sha256=9a294bb0acb1a539ed19f0e511098a9740b4aab4389e169585e8da1337fbd8b4
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  wai-website-plugin (0.3)
+  wai-website-theme (1.10)
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
 BUNDLED WITH
-   2.5.14
+  4.0.3

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ kramdown:
   syntax_highlighter: rouge
 highlighter: rouge
 
-remote_theme: w3c/wai-website-theme
+theme: wai-website-theme
 
 defaults:
   -

--- a/_config.yml
+++ b/_config.yml
@@ -7,12 +7,11 @@
 
 # Site settings
 title: "Web Accessibility Initiative (WAI)"
-email: your-email@domain.com
-description: > # this means to ignore newlines until "baseurl:"
+description: >
   The Website of the World Wide Web Consortium’s Web Accessibility Initiative.
 warning_message: >
   This is a local preview of ARRM. The published version is at <a href="https://www.w3.org/WAI/planning/arrm/">w3.org/WAI/planning/arrm/</a>.
-baseurl: "/wai-arrm" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://w3c.github.io" # the base hostname & protocol for your site
 author: w3c_wai
 exclude:
@@ -21,6 +20,9 @@ exclude:
   - "Gemfile.lock"
   - "README.md"
   - "w3c.json"
+  - "node_modules"
+repository: w3c/wai-arrm
+branch: draft
 
 # Build settings
 markdown: kramdown
@@ -29,7 +31,6 @@ kramdown:
   input: GFM
   syntax_highlighter: rouge
 highlighter: rouge
-repository: w3c/wai-arrm
 
 remote_theme: w3c/wai-website-theme
 
@@ -55,12 +56,3 @@ defaults:
       image:
         path: /content-images/wai-arrm/arrm-social.png
         alt: Accessibility Roles and Responsibilities Mapping (ARRM). W3C Web Accessibility Initiative (WAI). icons of hand, eye, brain, ear, speech, body.
-
-plugins:
-  - jekyll-seo-tag
-  - jekyll-sitemap
-  - jekyll-redirect-from
-  - jekyll-include-cache
-  - jekyll-paginate
-  - jekyll-remote-theme
-  - wai-website-plugin

--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,8 @@ description: >
   The Website of the World Wide Web Consortium’s Web Accessibility Initiative.
 warning_message: >
   This is a local preview of ARRM. The published version is at <a href="https://www.w3.org/WAI/planning/arrm/">w3.org/WAI/planning/arrm/</a>.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://w3c.github.io" # the base hostname & protocol for your site
+baseurl: "/wai-arrm" # the subpath of your site (for GitHub Pages)
+url: "https://w3c.github.io" # the base hostname & protocol for your site (for GitHub Pages)
 author: w3c_wai
 exclude:
   - "_external"

--- a/_data/lang.json
+++ b/_data/lang.json
@@ -1,1 +1,0 @@
-../_external/data/lang.json

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,1 +1,0 @@
-../_external/data/navigation.yml

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -1,1 +1,0 @@
-../_external/data/translations.yml

--- a/_data/wcag22.json
+++ b/_data/wcag22.json
@@ -1,1 +1,0 @@
-../_external/data/wcag22.json

--- a/content/acknowledgements.md
+++ b/content/acknowledgements.md
@@ -9,9 +9,6 @@ parent_in_h1:
   - ref: /planning/arrm/
     name: nav_title
 
-github:
-  path: content/acknowledgements.md
-
 permalink: /planning/arrm/acknowledgements/
 ref: /planning/arrm/acknowledgements/   
 

--- a/content/content-author.md
+++ b/content/content-author.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors'
 
-github:
-  path: content/content-author.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/content-author/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/content-author/    # Do not change this
 

--- a/content/decision-tree.md
+++ b/content/decision-tree.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/decision-tree.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/decision-tree/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/decision-tree/    # Do not change this
 

--- a/content/front-end.md
+++ b/content/front-end.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/front-end.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/front-end/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/front-end/    # Do not change this
 

--- a/content/index.md
+++ b/content/index.md
@@ -14,9 +14,6 @@ last_updated: 2025-07-24   # Keep the date of the English version
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/index.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/    # Do not change this
 

--- a/content/roles.md
+++ b/content/roles.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/roles.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/roles/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/roles/    # Do not change this
 

--- a/content/tasks.md
+++ b/content/tasks.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/tasks.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/tasks/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/tasks/    # Do not change this
 

--- a/content/user-experience.md
+++ b/content/user-experience.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/user-experience.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/user-experience/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/user-experience/    # Do not change this
 

--- a/content/visual-designer.md
+++ b/content/visual-designer.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/visual-designer.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/visual-designer/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/visual-designer/    # Do not change this
 

--- a/content/wcag-sc.md
+++ b/content/wcag-sc.md
@@ -18,9 +18,6 @@ parent_in_h1:
 # - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-github:
-  path: content/wcag-sc.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
-
 permalink: /planning/arrm/wcag-sc/  # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
 ref: /planning/arrm/wcag-sc/    # Do not change this
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "git submodule update --init --remote && bundle exec jekyll build --co
 publish = "_site"
 
 [build.environment]
-RUBY_VERSION = "3.3.3"
+RUBY_VERSION = "3.4.8"
 
 [[redirects]]
   from = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "git submodule update --init --remote && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
+command = "bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
 publish = "_site"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "bundle update wai-website-theme && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
+command = "bundle update wai-website-theme --conservative && bundle update wai-website-plugin --conservative && bundle update wai-website-theme && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
 publish = "_site"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
+command = "bundle update wai-website-theme && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
 publish = "_site"
 
 [build.environment]


### PR DESCRIPTION
This PR removes the `wai-website-data` submodule that was previously used to get:
- the data for the navigation and for UI translations,
- and the Ruby gems shared across WAI website repositories.

This data is now inherited from the `wai-website-theme` or `wai-website-plugin` gems. In turn, this repository does not use submodules anymore. 

This PR also updates the Ruby version used from 3.3.3 to 3.4.8, and the Bundler version from 2.5.14 to 4.0.3. 

The Netlify configuration now:
- uses Ruby 3.4.8
- fetches the latest version of the `wai-website-theme` and `wai-website-plugin` gems before building the site.

## How to build the site locally from now on

Refer to the the updated [README](https://github.com/w3c/wai-arrm?tab=readme-ov-file).

## How to update Ruby locally:
- Install Ruby 3.4.8. [Jekyll recommends using `ruby-install`](https://jekyllrb.com/docs/installation/macos/):
  ```
  ruby-install ruby 3.4.8
  ```
- Configure your version manager to use Ruby 3.4.8. [Jekyll recommends using `chruby`](https://jekyllrb.com/docs/installation/macos/):
   ```
    chruby ruby-3.4.8
   ```
- Update your `~/.zshrc` file to use Ruby 3.4.8 by default (optional)

  ```
  chruby ruby-3.4.8
  ```

For more context on the changes made to the theme and the wai-website-plugin, see https://github.com/w3c/wai-website-theme/pull/171, https://github.com/w3c/wai-website-theme/pull/173 and https://github.com/w3c/wai-website-plugin/pull/4

<details>
<summary>Tasks</summary> 

To do, after merging https://github.com/w3c/wai-website-plugin/pull/4 and https://github.com/w3c/wai-website-theme/pull/173:
- [x] Update the `Gemfile` to use the `main` branch for the `wai-website-plugin` and the `wai-website-theme`
- [x] Run `bundle install` and commit `Gemfile.lock`

</details>
