### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
   remote: https://github.com/w3c/wai-website-plugin
-  revision: e9f2c0e098caf80e010f1985ba942b6bf540e85e
+  revision: 9f884051344eff6eff0b7aaea86f5077b210377d
   branch: main
   specs:
-    wai-website-plugin (0.3)
+    wai-website-plugin (0.3.2)
       jekyll (~> 4.4.1)
-      nokogiri (~> 1.19.0)
+      nokogiri (~> 1.19.4)
 
 GIT
   remote: https://github.com/w3c/wai-website-theme
-  revision: f33b9fef553b59ef8ecf35c3bef264de8b1ad4a9
+  revision: 468c42cf13a29f4921df47caae7abc35269a77ff
   branch: main
   specs:
     wai-website-theme (1.10)
@@ -90,9 +90,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.4.0)
-    nokogiri (1.19.0-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.0-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -153,8 +153,8 @@ CHECKSUMS
   listen (3.9.0) sha256=db9e4424e0e5834480385197c139cb6b0ae0ef28cc13310cfd1ca78377d59c67
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
-  nokogiri (1.19.0-arm64-darwin) sha256=0811dfd936d5f6dd3f6d32ef790568bf29b2b7bead9ba68866847b33c9cf5810
-  nokogiri (1.19.0-x86_64-linux-gnu) sha256=f482b95c713d60031d48c44ce14562f8d2ce31e3a9e8dd0ccb131e9e5a68b58c
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
   public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
@@ -168,7 +168,7 @@ CHECKSUMS
   sass-embedded (1.97.1-x86_64-linux-gnu) sha256=9a294bb0acb1a539ed19f0e511098a9740b4aab4389e169585e8da1337fbd8b4
   terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
-  wai-website-plugin (0.3)
+  wai-website-plugin (0.3.2)
   wai-website-theme (1.10)
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 


### PR DESCRIPTION
Including bumping nokogiri from 1.19.3 to 1.19.4 via the wai-website-plugin.